### PR TITLE
Gra 65

### DIFF
--- a/web/components/card.tsx
+++ b/web/components/card.tsx
@@ -25,7 +25,7 @@ export default function Card({
 }: CardProps) {
   const flexDirection = flexDir === 'row' ? 'flex-row' : 'flex-col'
   const gapClass = gap ? `gap-${gap}` : 'gap-4'
-  const bgColorClass = bgColor === 'blue' ? 'bg-blue-100' : 'bg-white'
+  const bgColorClass = bgColor === 'blue' ? 'bg-[#441AFF]' : 'bg-white'
 
   // 各パディングを個別に適用
   const pad = (dir: keyof typeof padding) =>

--- a/web/components/timelimit.tsx
+++ b/web/components/timelimit.tsx
@@ -1,56 +1,58 @@
-// components/timelimit.tsx
 import React, { useEffect, useState } from 'react'
 import Card from './card'
 
-// <TimeLimit initialTime={10} openTime={10000000} />
-
 interface TimeLimitProps {
-  initialTime: number
-  openTime: number
+  initialTime: number // アップロード終了時刻（getTime()の値）
+  openTime: number // 開封時刻（getTime()の値）
+}
+
+interface TimeUnits {
+  days: number
+  hours: number
+  minutes: number
+  seconds: number
 }
 
 const TimeLimit: React.FC<TimeLimitProps> = ({ initialTime, openTime }) => {
-  const [timeLeft, setTimeLeft] = useState(initialTime)
-  const [isClient, setIsClient] = useState(false)
-  const [displayText, setDisplayText] = useState('アップロード終了まで')
+  const [timeLeft, setTimeLeft] = useState<number>(initialTime - Date.now()) // 残り時間（ミリ秒）
+  const [isUploadPhase, setIsUploadPhase] = useState<boolean>(true) // アップロード中かどうか
 
   useEffect(() => {
-    setIsClient(true)
-  }, [])
+    const timer: NodeJS.Timeout = setInterval(() => {
+      const now = Date.now()
+      const remainingTime = isUploadPhase ? initialTime - now : openTime - now
 
-  useEffect(() => {
-    if (!isClient) return
-
-    if (timeLeft <= 0) {
-      if (displayText === 'アップロード終了まで') {
-        setDisplayText('開封まで')
-        setTimeLeft(openTime)
+      if (remainingTime <= 0) {
+        if (isUploadPhase) {
+          setIsUploadPhase(false)
+          setTimeLeft(openTime - now)
+        } else {
+          clearInterval(timer)
+          setTimeLeft(0)
+        }
+      } else {
+        setTimeLeft(remainingTime)
       }
-      return
-    }
-
-    const timer = setInterval(() => {
-      setTimeLeft((prevTime) => prevTime - 1)
     }, 1000)
 
     return () => clearInterval(timer)
-  }, [timeLeft, isClient, displayText, openTime])
+  }, [isUploadPhase, initialTime, openTime])
 
-  if (!isClient) return null
-
-  const calculateTimeUnits = (seconds: number) => {
+  const calculateTimeUnits = (milliseconds: number): TimeUnits => {
+    const seconds = Math.max(0, Math.floor(milliseconds / 1000))
     const days = Math.floor(seconds / (24 * 60 * 60))
     const hours = Math.floor((seconds % (24 * 60 * 60)) / (60 * 60))
     const minutes = Math.floor((seconds % (60 * 60)) / 60)
-    return { days, hours, minutes }
+    const remainingSeconds = seconds % 60
+    return { days, hours, minutes, seconds: remainingSeconds }
   }
 
-  const { days, hours, minutes } = calculateTimeUnits(timeLeft)
+  const { days, hours, minutes, seconds } = calculateTimeUnits(timeLeft)
 
   return (
     <div className="p-4 flex items-center justify-center">
       <Card
-        bgColor={'blue'}
+        bgColor="blue"
         padding={{
           top: 10,
           bottom: 10,
@@ -59,11 +61,23 @@ const TimeLimit: React.FC<TimeLimitProps> = ({ initialTime, openTime }) => {
         }}
       >
         <div className="absolute w-[140px] h-[40px] bg-white -top-1 -left-1.5 flex items-center justify-center rounded-br-2xl font-bold">
-          <div className="text-xs text-[#441AFF]">{displayText}</div>
+          <div className="text-xs text-[#441AFF]">
+            {isUploadPhase ? 'アップロード終了まで' : '開封まで'}
+          </div>
         </div>
         <div className="flex items-center justify-center tracking-widest text-white text-4xl font-black">
-          {days}
-          <div className="text-sm pt-2.5">日　　</div> {hours}：{minutes}
+          {days > 0 ? (
+            <>
+              {days}
+              <div className="text-sm pt-2.5">日　　</div> {hours}：{minutes}
+            </>
+          ) : (
+            <>
+              {String(hours).padStart(2, '0')}：
+              {String(minutes).padStart(2, '0')}：
+              {String(seconds).padStart(2, '0')}
+            </>
+          )}
         </div>
       </Card>
     </div>

--- a/web/components/timelimit.tsx
+++ b/web/components/timelimit.tsx
@@ -1,0 +1,73 @@
+// components/timelimit.tsx
+import React, { useEffect, useState } from 'react'
+import Card from './card'
+
+// <TimeLimit initialTime={10} openTime={10000000} />
+
+interface TimeLimitProps {
+  initialTime: number
+  openTime: number
+}
+
+const TimeLimit: React.FC<TimeLimitProps> = ({ initialTime, openTime }) => {
+  const [timeLeft, setTimeLeft] = useState(initialTime)
+  const [isClient, setIsClient] = useState(false)
+  const [displayText, setDisplayText] = useState('アップロード終了まで')
+
+  useEffect(() => {
+    setIsClient(true)
+  }, [])
+
+  useEffect(() => {
+    if (!isClient) return
+
+    if (timeLeft <= 0) {
+      if (displayText === 'アップロード終了まで') {
+        setDisplayText('開封まで')
+        setTimeLeft(openTime)
+      }
+      return
+    }
+
+    const timer = setInterval(() => {
+      setTimeLeft((prevTime) => prevTime - 1)
+    }, 1000)
+
+    return () => clearInterval(timer)
+  }, [timeLeft, isClient, displayText, openTime])
+
+  if (!isClient) return null
+
+  const calculateTimeUnits = (seconds: number) => {
+    const days = Math.floor(seconds / (24 * 60 * 60))
+    const hours = Math.floor((seconds % (24 * 60 * 60)) / (60 * 60))
+    const minutes = Math.floor((seconds % (60 * 60)) / 60)
+    return { days, hours, minutes }
+  }
+
+  const { days, hours, minutes } = calculateTimeUnits(timeLeft)
+
+  return (
+    <div className="p-4 flex items-center justify-center">
+      <Card
+        bgColor={'blue'}
+        padding={{
+          top: 10,
+          bottom: 10,
+          left: 4,
+          right: 4,
+        }}
+      >
+        <div className="absolute w-[140px] h-[40px] bg-white -top-1 -left-1.5 flex items-center justify-center rounded-br-2xl font-bold">
+          <div className="text-xs text-[#441AFF]">{displayText}</div>
+        </div>
+        <div className="flex items-center justify-center tracking-widest text-white text-4xl font-black">
+          {days}
+          <div className="text-sm pt-2.5">日　　</div> {hours}：{minutes}
+        </div>
+      </Card>
+    </div>
+  )
+}
+
+export default TimeLimit


### PR DESCRIPTION
# タイトル
<!-- Pull Requestのタイトルを記入してください -->
TimeLimitコンポーネントの「アップロード終了まで」と「開封まで」の時間表示機能の追加
## 概要
<!-- Pull Requestの概要を簡潔に記述してください -->
「アップロード終了まで」と「開封まで」の2段階のカウントダウン表示を実現するTimeLimitコンポーネントの機能を追加しました。最初のカウントダウンが0になると、テキストと残り時間がリセットされ、2つ目のカウントダウンが開始されます。
## 変更内容

- 2段階のカウントダウンを実現するためのロジックをTimeLimitコンポーネントに追加

- displayTextとtimeLeftを動的に変更し、初期カウントダウンが終了した際に表示テキストと時間が切り替わるように設定

- 新しい時間設定ができるように、openTimeプロパティを追加

## 新規関数
<!-- 新規関数がある場合、関数名、引数、戻り値を記述してください -->
- ### 関数名: `<calculateTimeUnits>`
  - **引数**
    - `seconds`: `残り時間を秒単位で受け取り、日、時間、分に変換`
  - **戻り値**
    - `{ days, hours, minutes }`:`日、時間、分に変換したオブジェクト`
